### PR TITLE
Set the line length limit to 180 characters

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -32,6 +32,11 @@
             <property name="lineLimit" value="180"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Files.LineLength">
+        <properties>
+            <property name="lineLengthLimit" value="180"/>
+        </properties>
+    </rule>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array" value="array=>null,var_dump=>null,dump=>null" />


### PR DESCRIPTION
The `Generic.Files.LineLength` rule was already set to 180 characters.
The `SlevomatCodingStandard.Files.LineLength` rule was missing.
