### PR TITLE
feat: Remove compatibility with PHP < 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     }
   },
   "require": {
-    "php": "^7.4 || ^8.0",
-    "slevomat/coding-standard": "^8.8",
-    "squizlabs/php_codesniffer": "^3.6"
+    "php": "^8.0",
+    "slevomat/coding-standard": "^8.10",
+    "squizlabs/php_codesniffer": "^3.7"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
-    "symfony/var-dumper": "^5.4"
+    "phpunit/phpunit": "^9.6",
+    "symfony/var-dumper": "^6.0"
   },
   "config": {
     "allow-plugins": {

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -2,6 +2,7 @@
 <ruleset name="PcComponentes Coding Standard">
     <rule ref="PSR2" />
     <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/ruleset.xml">
+        <exclude name="SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys.IncorrectKeyOrder" />
         <exclude name="SlevomatCodingStandard.Classes.ClassConstantVisibility" />
         <exclude name="SlevomatCodingStandard.Classes.ClassLength.ClassTooLong" />
         <exclude name="SlevomatCodingStandard.Classes.DisallowConstructorPropertyPromotion" />


### PR DESCRIPTION
- **Remove compatibility with PHP < 8.0**
- Exclude rule: `SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys.IncorrectKeyOrder`