### PR TITLE
fix: Skip match function

### DIFF
--- a/src/Sniffs/PHP/LineBreakBeforeOutflowSniff.php
+++ b/src/Sniffs/PHP/LineBreakBeforeOutflowSniff.php
@@ -24,6 +24,7 @@ final class LineBreakBeforeOutflowSniff implements Sniff
     private const LINE_BREAKS_EXCEPTIONS = [
         T_OPEN_CURLY_BRACKET => 1,
         T_COLON => 1,
+        T_MATCH_ARROW => 0,
     ];
 
     /**
@@ -92,8 +93,7 @@ final class LineBreakBeforeOutflowSniff implements Sniff
     {
         return true === array_key_exists($code, self::LINE_BREAKS_EXCEPTIONS)
             ? self::LINE_BREAKS_EXCEPTIONS[$code]
-            : self::DEFAULT_LINE_BREAKS
-        ;
+            : self::DEFAULT_LINE_BREAKS;
     }
 
     private function numberOfLineBreaks(array $tokens, int $start, int $finish): int

--- a/tests/Sniffs/ControlStructures/data/lineBreakBetweenFunctionsErrors.fixed.php
+++ b/tests/Sniffs/ControlStructures/data/lineBreakBetweenFunctionsErrors.fixed.php
@@ -34,5 +34,5 @@ if (true) {
 match ('hello') {
     'hello' => 'bye',
     'bye' => 'hello',
-    default => null,
+    default => throw new \Exception('hello'),
 };

--- a/tests/Sniffs/ControlStructures/data/lineBreakBetweenFunctionsErrors.php
+++ b/tests/Sniffs/ControlStructures/data/lineBreakBetweenFunctionsErrors.php
@@ -34,5 +34,5 @@ if (true) {
 match ('hello') {
     'hello' => 'bye',
     'bye' => 'hello',
-    default => null,
+    default => throw new \Exception('hello'),
 };

--- a/tests/Sniffs/PHP/data/lineBreakBeforeOutflowErrors.fixed.php
+++ b/tests/Sniffs/PHP/data/lineBreakBeforeOutflowErrors.fixed.php
@@ -60,3 +60,9 @@ switch (true) {
 
         return 'default';
 }
+
+match ('hello') {
+    'hello' => 'bye',
+    'bye' => 'hello',
+    default => throw new \Exception('hello'),
+};

--- a/tests/Sniffs/PHP/data/lineBreakBeforeOutflowErrors.php
+++ b/tests/Sniffs/PHP/data/lineBreakBeforeOutflowErrors.php
@@ -60,3 +60,9 @@ switch (true) {
         \strval($item);
         return 'default';
 }
+
+match ('hello') {
+    'hello' => 'bye',
+    'bye' => 'hello',
+    default => throw new \Exception('hello'),
+};


### PR DESCRIPTION
#22

Before it gave an error and was formatted this way:
```php
match ('hello') {
    'hello' => 'bye',
    'bye' => 'hello',
    default =>
    throw new \Exception('hello'),
};
```

Is now skiped so that it stays like this:
```php
match ('hello') {
    'hello' => 'bye',
    'bye' => 'hello',
    default => throw new \Exception('hello'),
};
```