### PR TITLE
feat: Remove deprecated syntax and sniffs reported

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -41,6 +41,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
         <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint" />
+        <exclude name="SlevomatCodingStandard.TypeHints.UnionTypeHintFormat" />
         <exclude name="PSR2.Namespaces.UseDeclaration.MultipleDeclarations" />
     </rule>
     <rule ref="Generic.Files.LineLength">
@@ -51,6 +52,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="linesCountBeforeDeclare" value="0"/>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.Files.LineLength">
@@ -60,15 +62,14 @@
     </rule>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
-            <property name="forbiddenFunctions" type="array" value="array=>null,var_dump=>null,dump=>null" />
+            <property name="forbiddenFunctions" type="array">
+                <element key="array" value="null" />
+                <element key="var_dump" value="null" />
+                <element key="dump" value="null" />
+            </property>
         </properties>
     </rule>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireYodaComparison" />
-    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
-        <properties>
-            <property name="spacesCountAroundEqualsSign" value="0"/>
-        </properties>
-    </rule>
     <rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
         <properties>
             <property name="linesCountBeforeFirstUse" value="0"/>


### PR DESCRIPTION
Remove deprecated syntax and sniffs reported by PHP_CodeSniffer.
- Replaced the deprecated comma-separated string syntax for the `forbiddenFunctions` property with the recommended `<element>` array format.
- Removed usage of the deprecated `SlevomatCodingStandard.TypeHints.UnionTypeHintFormat` sniff and replaced it with `SlevomatCodingStandard.TypeHints.DNFTypeHintFormat`, as required by the latest Slevomat Coding Standard guidelines.

### Output before the MR
```
DEPRECATED: Passing an array of values to a property using a comma-separated string
was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0.
The deprecated syntax was used for property "forbiddenFunctions"
for sniff "Generic.PHP.ForbiddenFunctions".
Pass array values via <element [key="..." ]value="..."> nodes instead.

WARNING: The Project rules standard uses 1 deprecated sniff
----------------------------------------------------------------------------------------------------------------------------------------------------
-  SlevomatCodingStandard.TypeHints.UnionTypeHintFormat
   This sniff has been deprecated since Slevomat Coding Standard 8.16.0 and will be removed in Slevomat Coding Standard 9.0.0. Use
   SlevomatCodingStandard.TypeHints.DNFTypeHintFormat instead.

Deprecated sniffs are still run, but will stop working at some point in the future.
```